### PR TITLE
breaking: replace Field.Get() with Field.IsZeroValue()

### DIFF
--- a/flat/field.go
+++ b/flat/field.go
@@ -40,8 +40,7 @@ func (f *field) String() string {
 }
 
 func (f *field) Get() interface{} {
-	// return f.ptr
-	return nil
+	return f.field.Interface()
 }
 
 var textUnmarshalerType = reflect.TypeOf(new(encoding.TextUnmarshaler)).Elem()

--- a/flat/field.go
+++ b/flat/field.go
@@ -39,12 +39,8 @@ func (f *field) String() string {
 	return f.tag.Get("default")
 }
 
-func (f *field) IsZeroValue() bool {
-	fieldType := reflect.TypeOf(f.field.Interface())
-
-	return fieldType == nil ||
-		fieldType.Comparable() &&
-		f.field.Interface() == reflect.Zero(fieldType).Interface()
+func (f *field) IsZero() bool {
+	return f.field.IsValid() && f.field.IsZero()
 }
 
 var textUnmarshalerType = reflect.TypeOf(new(encoding.TextUnmarshaler)).Elem()

--- a/flat/field.go
+++ b/flat/field.go
@@ -39,8 +39,12 @@ func (f *field) String() string {
 	return f.tag.Get("default")
 }
 
-func (f *field) Get() interface{} {
-	return f.field.Interface()
+func (f *field) IsZeroValue() bool {
+	fieldType := reflect.TypeOf(f.field.Interface())
+
+	return fieldType == nil ||
+		fieldType.Comparable() &&
+		f.field.Interface() == reflect.Zero(fieldType).Interface()
 }
 
 var textUnmarshalerType = reflect.TypeOf(new(encoding.TextUnmarshaler)).Elem()

--- a/flat/field_test.go
+++ b/flat/field_test.go
@@ -1,6 +1,7 @@
 package flat_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,7 +11,8 @@ import (
 func TestField(t *testing.T) {
 
 	type Config struct {
-		First string `default:"first" test:"test-tag"`
+		First  string `default:"first" test:"test-tag"`
+		Second error
 	}
 
 	conf := Config{}
@@ -35,6 +37,10 @@ func TestField(t *testing.T) {
 		t.Errorf("expected tag test to be test-tag but got %v", tag)
 	}
 
+	if !firstField.IsZeroValue() {
+		t.Error("expected IsZeroValue() to return true")
+	}
+
 	meta1 := firstField.Meta()
 	meta2 := firstField.Meta()
 
@@ -52,12 +58,19 @@ func TestField(t *testing.T) {
 		t.Errorf("expected Set() to return nil but got: %v", err)
 	}
 
-	value, ok := firstField.Get().(string)
-	if !ok {
-		t.Errorf("expected Get() to return string interface{} but got %v", firstField.Get())
+	if firstField.IsZeroValue() {
+		t.Error("expected IsZeroValue() to return false")
 	}
 
-	if value != "some-value" {
-		t.Errorf("expected Get() value to be okay but got %v", value)
+	secondField := fs[1]
+
+	if !secondField.IsZeroValue() {
+		t.Error("expected IsZeroValue() to return true")
+	}
+
+	conf.Second = errors.New("oh no")
+
+	if secondField.IsZeroValue() {
+		t.Error("expected IsZeroValue() to return false")
 	}
 }

--- a/flat/field_test.go
+++ b/flat/field_test.go
@@ -47,4 +47,17 @@ func TestField(t *testing.T) {
 	if def := firstField.String(); def != "first" {
 		t.Errorf("expected String() to return default tag value but got %v", def)
 	}
+
+	if err := firstField.Set("some-value"); err != nil {
+		t.Errorf("expected Set() to return nil but got: %v", err)
+	}
+
+	value, ok := firstField.Get().(string)
+	if !ok {
+		t.Errorf("expected Get() to return string interface{} but got %v", firstField.Get())
+	}
+
+	if value != "some-value" {
+		t.Errorf("expected Get() value to be okay but got %v", value)
+	}
 }

--- a/flat/flat.go
+++ b/flat/flat.go
@@ -24,7 +24,7 @@ type Field interface {
 
 	String() string
 	Set(string) error
-	Get() interface{}
+	IsZeroValue() bool
 }
 
 // View provides a flat view of the provided structs an array of fields.


### PR DESCRIPTION
Hello, I was writing a `required` plugin and noticed `Field.Get()` always returned `nil` which prevented me from seeing if the underlying value was ever set.

This PR addresses the issue I ran into.

----

The `required` plugin is viewable [here](https://github.com/joncfoo/uconfig/pull/1).  LMK if there's interest in a PR.