### PR TITLE
Underlying value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@
 language: go
 
 go: 
-  - 1.12.x
+  - 1.13.x
+  - stable
   - master
 
 script:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# uConfig [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/omeid/uconfig)  [![Build Status](https://travis-ci.org/omeid/uconfig.svg?branch=master)](https://travis-ci.org/omeid/uconfig) [![Go Report Card](https://goreportcard.com/badge/github.com/omeid/uconfig)](https://goreportcard.com/report/github.com/omeid/uconfig) [![Coverage](https://gocover.io/_badge/github.com/omeid/uconfig?update)](https://gocover.io/github.com/omeid/uconfig)
+# uConfig [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/omeid/uconfig) [![Build Status](https://app.travis-ci.com/omeid/uconfig.svg?branch=master)](https://app.travis-ci.com/omeid/uconfig) [![Go Report Card](https://goreportcard.com/badge/github.com/omeid/uconfig)](https://goreportcard.com/report/github.com/omeid/uconfig) [![Coverage](https://gocover.io/_badge/github.com/omeid/uconfig?update)](https://gocover.io/github.com/omeid/uconfig)
 
 
 Lightweight, zero-dependency, and extendable configuration management.

--- a/flat/field.go
+++ b/flat/field.go
@@ -40,8 +40,7 @@ func (f *field) String() string {
 }
 
 func (f *field) Get() interface{} {
-	// return f.ptr
-	return nil
+	return f.field.Interface()
 }
 
 var textUnmarshalerType = reflect.TypeOf(new(encoding.TextUnmarshaler)).Elem()

--- a/flat/field.go
+++ b/flat/field.go
@@ -39,12 +39,8 @@ func (f *field) String() string {
 	return f.tag.Get("default")
 }
 
-func (f *field) IsZeroValue() bool {
-	fieldType := reflect.TypeOf(f.field.Interface())
-
-	return fieldType == nil ||
-		fieldType.Comparable() &&
-		f.field.Interface() == reflect.Zero(fieldType).Interface()
+func (f *field) IsZero() bool {
+	return f.field.IsValid() && f.field.IsZero()
 }
 
 var textUnmarshalerType = reflect.TypeOf(new(encoding.TextUnmarshaler)).Elem()

--- a/flat/field.go
+++ b/flat/field.go
@@ -39,8 +39,12 @@ func (f *field) String() string {
 	return f.tag.Get("default")
 }
 
-func (f *field) Get() interface{} {
-	return f.field.Interface()
+func (f *field) IsZeroValue() bool {
+	fieldType := reflect.TypeOf(f.field.Interface())
+
+	return fieldType == nil ||
+		fieldType.Comparable() &&
+		f.field.Interface() == reflect.Zero(fieldType).Interface()
 }
 
 var textUnmarshalerType = reflect.TypeOf(new(encoding.TextUnmarshaler)).Elem()

--- a/flat/field_test.go
+++ b/flat/field_test.go
@@ -37,8 +37,8 @@ func TestField(t *testing.T) {
 		t.Errorf("expected tag test to be test-tag but got %v", tag)
 	}
 
-	if !firstField.IsZeroValue() {
-		t.Error("expected IsZeroValue() to return true")
+	if !firstField.IsZero() {
+		t.Error("expected IsZero() to return true")
 	}
 
 	meta1 := firstField.Meta()
@@ -58,19 +58,19 @@ func TestField(t *testing.T) {
 		t.Errorf("expected Set() to return nil but got: %v", err)
 	}
 
-	if firstField.IsZeroValue() {
-		t.Error("expected IsZeroValue() to return false")
+	if firstField.IsZero() {
+		t.Error("expected IsZero() to return false")
 	}
 
 	secondField := fs[1]
 
-	if !secondField.IsZeroValue() {
-		t.Error("expected IsZeroValue() to return true")
+	if !secondField.IsZero() {
+		t.Error("expected IsZero() to return true")
 	}
 
 	conf.Second = errors.New("oh no")
 
-	if secondField.IsZeroValue() {
-		t.Error("expected IsZeroValue() to return false")
+	if secondField.IsZero() {
+		t.Error("expected IsZero() to return false")
 	}
 }

--- a/flat/field_test.go
+++ b/flat/field_test.go
@@ -1,6 +1,7 @@
 package flat_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,7 +11,8 @@ import (
 func TestField(t *testing.T) {
 
 	type Config struct {
-		First string `default:"first" test:"test-tag"`
+		First  string `default:"first" test:"test-tag"`
+		Second error
 	}
 
 	conf := Config{}
@@ -35,6 +37,10 @@ func TestField(t *testing.T) {
 		t.Errorf("expected tag test to be test-tag but got %v", tag)
 	}
 
+	if !firstField.IsZeroValue() {
+		t.Error("expected IsZeroValue() to return true")
+	}
+
 	meta1 := firstField.Meta()
 	meta2 := firstField.Meta()
 
@@ -52,12 +58,19 @@ func TestField(t *testing.T) {
 		t.Errorf("expected Set() to return nil but got: %v", err)
 	}
 
-	value, ok := firstField.Get().(string)
-	if !ok {
-		t.Errorf("expected Get() to return string interface{} but got %v", firstField.Get())
+	if firstField.IsZeroValue() {
+		t.Error("expected IsZeroValue() to return false")
 	}
 
-	if value != "some-value" {
-		t.Errorf("expected Get() value to be okay but got %v", value)
+	secondField := fs[1]
+
+	if !secondField.IsZeroValue() {
+		t.Error("expected IsZeroValue() to return true")
+	}
+
+	conf.Second = errors.New("oh no")
+
+	if secondField.IsZeroValue() {
+		t.Error("expected IsZeroValue() to return false")
 	}
 }

--- a/flat/field_test.go
+++ b/flat/field_test.go
@@ -47,4 +47,17 @@ func TestField(t *testing.T) {
 	if def := firstField.String(); def != "first" {
 		t.Errorf("expected String() to return default tag value but got %v", def)
 	}
+
+	if err := firstField.Set("some-value"); err != nil {
+		t.Errorf("expected Set() to return nil but got: %v", err)
+	}
+
+	value, ok := firstField.Get().(string)
+	if !ok {
+		t.Errorf("expected Get() to return string interface{} but got %v", firstField.Get())
+	}
+
+	if value != "some-value" {
+		t.Errorf("expected Get() value to be okay but got %v", value)
+	}
 }

--- a/flat/flat.go
+++ b/flat/flat.go
@@ -24,7 +24,7 @@ type Field interface {
 
 	String() string
 	Set(string) error
-	Get() interface{}
+	IsZeroValue() bool
 }
 
 // View provides a flat view of the provided structs an array of fields.

--- a/flat/flat.go
+++ b/flat/flat.go
@@ -24,7 +24,7 @@ type Field interface {
 
 	String() string
 	Set(string) error
-	IsZeroValue() bool
+	IsZero() bool
 }
 
 // View provides a flat view of the provided structs an array of fields.


### PR DESCRIPTION
Allow checking if a field is set or not by exposing a `IsZero`.

It also drops `Get()` which was pretty much a useless method.